### PR TITLE
Updated CL & UY calendly URLs

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -246,9 +246,8 @@ export const getCalendlyURL = (country_code, email, name, phone) => {
   const urls = {
     'ar': `https://calendly.com/d/zr2q-96wm/argentina-agendamientos-carbula?month=${dayjs().format('YYYY-MM')}&hide_gdpr_banner=1&text_color=333333&primary_color=3074f1&email=${email}&name=${name}&a1=${phone}`,
     'mx': `https://calendly.com/carbulamex/visita?month=${dayjs().format('YYYY-MM')}&hide_gdpr_banner=1&text_color=333333&primary_color=3074f1&email=${email}&name=${name}`,
-    'uy': `https://calendly.com/d/ckh-qwz-mzm/uruguay-agendamientos-carbula?month=${dayjs().format('YYYY-MM')}&hide_gdpr_banner=1&text_color=333333&primary_color=3074f1&email=${email}&name=${name}&a1=${phone}`,
-    'cl': `https://calendly.com/d/ygfm-5xt9/chile-agendamientos-carbula?month=${dayjs().format('YYYY-MM')}&hide_gdpr_banner=1&text_color=333333&primary_color=3074f1&email=${email}&name=${name}&a1=${phone}`
-
+    'uy': `https://calendly.com/carbula-uy/agendar-visita?month=${dayjs().format('YYYY-MM')}&hide_gdpr_banner=1&text_color=333333&primary_color=3074f1&email=${email}&name=${name}&a1=${phone}`,
+    'cl': `https://calendly.com/carbula-cl/agendar-inspeccion?month=${dayjs().format('YYYY-MM')}&hide_gdpr_banner=1&text_color=333333&primary_color=3074f1&email=${email}&name=${name}&a1=${phone}`
   }
   return urls[country_code]
 }


### PR DESCRIPTION
## Descripción de la funcionalidad
Cambié las URIs de calendly para Chile y Uruguay

## Descripción del error


## Pasos para probar
Agendar una inspección y que quede agendada en el calendario correspondiente

## Screenshots


## Hay alguna otra sección del código / funcionalidad afectada por este cambio
No
