### PR TITLE
Added mask to mks input CL

### DIFF
--- a/components/SellFormChile/index.jsx
+++ b/components/SellFormChile/index.jsx
@@ -315,7 +315,12 @@ const SellFormChile = ({ step, setStep, setOverlayBackground, zonas, referer, CO
           </div>
           <div className={styles.form__row}>
             <div className='form-item'>
-              <input
+            <InputMask
+                formatChars={{
+                  'n': '[0-9]'
+                }}
+                mask={"nnnnnn"}
+                maskChar=""
                 onBlur={handleBlur}
                 name="kms"
                 type="text"


### PR DESCRIPTION
## Descripción de la funcionalidad
Se agrega máscara al input KMS del formulario de Chile

## Descripción del error
Se pueden registrar kms como decimales

## Pasos para probar
Entrar al formulario de Chile e intentar registrar un vehículo con más de 100.000 kms (no te tiene que dejar).
