### PR TITLE
Fix position title Mobile

### DIFF
--- a/pages/index/home.module.scss
+++ b/pages/index/home.module.scss
@@ -169,7 +169,7 @@
 
 @media (max-width: 426px) {
   .section1__title {
-    margin-top: 50px;
+    margin-top: 100px;
     width: 80%;
     display: inline-block;
   }
@@ -196,7 +196,7 @@
     margin: 0px 10px 0px 10px;
   }
   .section1__title {
-    margin-top: 50px;
+    margin-top: 120px;
     
   }
 }


### PR DESCRIPTION
## Descripción del error
Al desplegar el formulario en Paso 2, en vista mobile tapaba el texto "Compra y venta de autos usados"


